### PR TITLE
Cleanup intermediate files

### DIFF
--- a/gedi-subset/algorithm_config.yaml
+++ b/gedi-subset/algorithm_config.yaml
@@ -1,13 +1,13 @@
 description: Subset GEDI L4A granules within an area of interest (AOI)
 algo_name: gedi-subset
-version: gedi-subset
+version: main
 environment: ubuntu
 repository_url: https://repo.ops.maap-project.org/data-team/maap-documentation-examples.git
 docker_url: mas.maap-project.org:5000/root/ade-base-images/r:latest
-queue: maap-dps-worker-32gb
+queue: maap-dps-worker-8gb
 build_command: maap-documentation-examples/build.sh
 run_command: maap-documentation-examples/gedi-subset/subset.sh
-disk_space: 300GB
+disk_space: 20GB
 inputs:
   - name: aoi
     download: True

--- a/gedi-subset/gedi_utils.py
+++ b/gedi-subset/gedi_utils.py
@@ -9,6 +9,7 @@ import h5py
 import numpy as np
 import pandas as pd
 import requests
+from fp import K
 from maap.Result import Granule
 from returns.curry import curry, partial
 from returns.functions import identity
@@ -18,8 +19,6 @@ from returns.pipeline import flow
 from returns.pointfree import bimap, bind_ioresult, map_
 from shapely.geometry import Polygon
 from shapely.geometry.base import BaseGeometry
-
-from fp import K
 
 # Suppress UserWarning: The Shapely GEOS version (3.10.2-CAPI-1.16.0) is incompatible
 # with the GEOS version PyGEOS was compiled with (3.8.1-CAPI-1.13.3). Conversions
@@ -116,9 +115,7 @@ def gdf_to_file(
     props = dict(props, mode="w") if mode == "a" and not os.path.exists(file) else props
 
     logger.debug(
-        f"Empty GeoDataFrame; not writing {file}"
-        if gdf.empty
-        else f"Writing to {file}"
+        f"Empty GeoDataFrame; not writing {file}" if gdf.empty else f"Writing to {file}"
     )
 
     return (

--- a/gedi-subset/maapx.py
+++ b/gedi-subset/maapx.py
@@ -1,10 +1,11 @@
 import logging
 import operator
-from typing import Mapping, TYPE_CHECKING
+from typing import TYPE_CHECKING, Mapping
 
 import boto3
-from cachetools import cached, FIFOCache
+from cachetools import FIFOCache, cached
 from cachetools.func import ttl_cache
+from fp import K
 from maap.maap import MAAP
 from maap.Result import Collection, Granule
 from returns.curry import partial
@@ -14,8 +15,6 @@ from returns.maybe import Maybe, Nothing, Some, maybe
 from returns.pipeline import flow
 from returns.pointfree import bind, bind_ioresult, bind_result, lash, map_
 from returns.result import safe
-
-from fp import K
 
 if TYPE_CHECKING:
     from maap.AWS import AWSCredentials

--- a/gedi-subset/osx.py
+++ b/gedi-subset/osx.py
@@ -1,0 +1,7 @@
+import os
+import os.path
+
+from returns.io import impure_safe
+
+exists = impure_safe(os.path.exists)
+remove = impure_safe(os.remove)

--- a/gedi-subset/osx.py
+++ b/gedi-subset/osx.py
@@ -1,3 +1,15 @@
+"""Impure, safe wrappers of functions from the `os` module and sub-modules.
+
+Wrappers are named the same as the functions they wrap, and expect the same
+arguments, but never throw exceptions.  Instead, they return a value of the type
+returned by the wrapped function, but wrapped in an `IOResultE`.
+
+Functions:
+
+- exists wraps os.path.exists and returns IOResultE[bool]
+- remove wraps os.remove and returns IOResultE[None]
+"""
+
 import os
 import os.path
 

--- a/gedi-subset/subset.py
+++ b/gedi-subset/subset.py
@@ -65,7 +65,7 @@ def cpu_count() -> int:
 
 
 @impure_safe
-def process_granule(props: ProcessGranuleProps) -> Maybe[str]:
+def process_granule(props: ProcessGranuleProps) -> IOResultE[Maybe[str]]:
     filter_cols = [
         "agbd",
         "agbd_se",

--- a/gedi-subset/subset.py
+++ b/gedi-subset/subset.py
@@ -11,20 +11,8 @@ from pathlib import Path
 from typing import Any, Iterable, Tuple
 
 import geopandas as gpd
+import osx
 import typer
-from maap.maap import MAAP
-from maap.Result import Granule
-from returns.curry import partial
-from returns.functions import raise_exception, tap
-from returns.io import IO, IOResultE, IOSuccess, impure_safe
-from returns.iterables import Fold
-from returns.maybe import Maybe, Some, Nothing
-from returns.methods import unwrap_or_failure
-from returns.pipeline import flow, is_successful, pipe
-from returns.pointfree import bind_ioresult, lash, map_
-from returns.result import Failure, Success
-from returns.unsafe import unsafe_perform_io
-
 from fp import K, filter, map
 from gedi_utils import (
     append_gdf_file,
@@ -34,7 +22,19 @@ from gedi_utils import (
     granule_intersects,
     subset_h5,
 )
+from maap.maap import MAAP
+from maap.Result import Granule
 from maapx import download_granule, find_collection
+from returns.curry import partial
+from returns.functions import raise_exception, tap
+from returns.io import IO, IOResultE, IOSuccess, impure_safe
+from returns.iterables import Fold
+from returns.maybe import Maybe, Nothing, Some
+from returns.methods import unwrap_or_failure
+from returns.pipeline import flow, is_successful, pipe
+from returns.pointfree import bind_ioresult, cond, lash, map_
+from returns.result import Failure, Success
+from returns.unsafe import unsafe_perform_io
 
 
 class CMRHost(str, Enum):
@@ -54,7 +54,6 @@ class ProcessGranuleProps:
     maap: MAAP
     aoi_gdf: gpd.GeoDataFrame
     output_directory: Path
-    overwrite: bool
 
 
 def cpu_count() -> int:
@@ -82,15 +81,15 @@ def process_granule(props: ProcessGranuleProps) -> Maybe[str]:
 
     logger.debug(f"Subsetting {inpath} to {outpath}")
 
-    if props.overwrite or not os.path.exists(outpath):
-        flow(
-            subset_h5(inpath, props.aoi_gdf, filter_cols),
-            df_assign("filename", inpath),
-            gdf_to_file(outpath, dict(index=False, driver="FlatGeobuf")),
-            lash(raise_exception),
-        )
+    flow(
+        subset_h5(inpath, props.aoi_gdf, filter_cols),
+        df_assign("filename", inpath),
+        gdf_to_file(outpath, dict(index=False, driver="FlatGeobuf")),
+        bind_ioresult(lambda _: osx.remove(inpath)),
+        lash(raise_exception),
+    )
 
-    return Some(outpath) if os.path.exists(outpath) else Nothing
+    return osx.exists(outpath).bind(cond(Maybe, outpath))
 
 
 def init_process(logging_level: int) -> None:
@@ -107,7 +106,6 @@ def subset_granules(
     aoi_gdf: gpd.GeoDataFrame,
     output_directory: Path,
     dest: Path,
-    overwrite: bool,
     init_args: Tuple[Any, ...],
     granules: Iterable[Granule],
 ) -> IOResultE[Tuple[str, ...]]:
@@ -118,7 +116,7 @@ def subset_granules(
     logger.info(f"Subsetting on {processes} processes (chunksize={chunksize})")
 
     props = (
-        ProcessGranuleProps(granule, maap, aoi_gdf, output_directory, overwrite)
+        ProcessGranuleProps(granule, maap, aoi_gdf, output_directory)
         for granule in granules
     )
 
@@ -129,6 +127,7 @@ def subset_granules(
             map(map_(unwrap_or_failure)),
             map(tap(map_(pipe(f"Appending {{}} to {dest}".format, logger.debug)))),
             map(bind_ioresult(partial(append_gdf_file, dest))),
+            map(bind_ioresult(lambda src: osx.remove(src).map(K(src)))),
             partial(Fold.collect, acc=IOSuccess(())),
         )
 
@@ -169,10 +168,6 @@ def main(
         readable=True,
         resolve_path=True,
     ),
-    overwrite: bool = typer.Option(
-        False,
-        help="Overwrite individual subset files",
-    ),
     verbose: bool = typer.Option(False, help="Provide verbose output"),
 ) -> None:
     logging_level = logging.DEBUG if verbose else logging.INFO
@@ -185,7 +180,7 @@ def main(
     # testing.  When running in the context of a DPS job, there
     # should be no existing file since every job uses a unique
     # output directory.
-    impure_safe(os.remove)(dest)
+    osx.remove(dest)
 
     maap = MAAP("api.ops.maap-project.org")
 
@@ -206,7 +201,6 @@ def main(
             aoi_gdf,
             output_directory,
             dest,
-            overwrite,
             (logging_level,),
             filter(partial(granule_intersects, aoi_gdf.geometry[0]))(granules),
         )


### PR DESCRIPTION
Cleans up intermediate files generated during subsetting (downloaded h5 files as well as corresponding subset files) to minimize disk space, and leaving only the final, combined subset file as output.

Further, applied `isort` and `black` to tidy up imports and formatting, along with a couple of type hint fixes and adjusting the algorithm configuration to use the 8gb queue and dial down the disk space.