### PR TITLE
Fix DPS build script to install correct maap-py version

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -24,7 +24,7 @@ esac
 conda create -y -n gedi_subset --file "${basedir}/gedi-subset/conda-${platform}-64.lock"
 
 # Install maap-py, since it cannot be specified in the lock file
-conda run --no-capture-output -n gedi_subset pip install "git+https://github.com/MAAP-Project/maap-py.git@1bfa99d#egg=maappy"
+conda run --no-capture-output -n gedi_subset pip install -r gedi-subset/requirements-maappy.txt
 
 # Fail build if finicky mix of fiona and gdal isn't correct, so that we don't
 # have to wait to execute a DPS job to find out.

--- a/environment.yml
+++ b/environment.yml
@@ -14,4 +14,4 @@ dependencies:
   - shapely==1.8.2
   - pip
   - pip:
-      - git+https://github.com/MAAP-Project/maap-py.git@hotfixes#egg=maappy
+      - -r gedi-subset/requirements-maappy.txt

--- a/gedi-subset/CHANGELOG.md
+++ b/gedi-subset/CHANGELOG.md
@@ -7,6 +7,12 @@ variation of [Semantic Versioning], with the following difference: each version
 is prefixed with `gedi-subset-` (e.g., `gedi-subset-0.1.0`) to allow for
 distinct lines of versioning of independent work in sibling directories.
 
+## [gedi-subset-0.2.3] - 2022-08-03
+
+### Fixed
+
+- `build.sh` now installs the correct version of `maap-py` (`hotfixes` branch)
+
 ## [gedi-subset-0.2.2] - 2022-08-02
 
 ### Changed

--- a/gedi-subset/README.md
+++ b/gedi-subset/README.md
@@ -259,14 +259,26 @@ explained below.
 
 1. Create a new branch based on an appropriate existing branch (typically based
    on `main`).
-1. In addition to your desired code and/or configuration changes, do the
-   following:
-   1. Update `version` in `gedi-subset/algorithm_config.yaml` according to the
-      versioning convention referenced in the [Changelog](./CHANGELOG.md).
-   1. Add appropriate entries to the [Changelog](./CHANGELOG.md), according to
-      the Changelog convention referenced in the file.  In particular, you
-      should add a new section using the same version as specified in
-      `gedi-subset/algorithm_config.yaml`, with appropriate subsections.
+1. Add your desired code and/or configuration changes.
+1. Update the value of `version` in `gedi-subset/algorithm_config.yaml`
+   according to the versioning convention referenced at the top of the
+   [Changelog](./CHANGELOG.md).
+1. Add appropriate entries to the [Changelog](./CHANGELOG.md), according to
+   the [Keep a Changelog] convention.  In particular:
+   - Add a new, second-level section of the following form:
+
+      ```plain
+      ## [VERSION] - YYYY-MM-DD
+      ```
+
+      where:
+      - `VERSION` is the value of `version` specified in
+        `gedi-subset/algorithm_config.yaml`
+      - `YYYY-MM-DD` is the date that you expect to create the release (see the
+        following steps), which may or may not be the current date, depending
+        upon when you expect your PR (next step) to be approved and merged.
+   - Add appropriate third-level sections under the new version section (for
+     additions, changes, and fixes).  Again, see [Keep a Changelog].
 1. Submit a PR to the GitHub repository.
 1. _Only when_ the PR is on a branch to be merged into the `main` branch _and_
    it has been approved and merged, create a new release in GitHub as follows:
@@ -279,7 +291,8 @@ explained below.
    1. In the **Release title** input, also enter the _same_ value as the new
       value of `version` in `gedi-subset/algorithm_config.yml`.
    1. In the description text box, copy and paste from the Changelog file only
-      the _new version section_ you added earlier to the Changelog.
+      the _new version section_ you added earlier to the Changelog, including
+      the new version heading.
    1. Click the **Publish release** button.
 
 ### Registering an Algorithm Release
@@ -304,6 +317,9 @@ able to register the new version of the algorithm, as follows, within the ADE:
    git push --tags ade
    ```
 
+   **NOTE:** On occassion, you might get a "server certificate verification
+   failed" error attempting to push to GitLab.  If so, simply prefix the
+   preceding commands with `GIT_SSL_NO_VERIFY=1`
 1. In the ADE's File Browser, navigate to
    `maap-documentation-examples/gedi-subset`.
 1. Right-click on `algorithm_config.yaml` and choose **Register as MAS
@@ -333,6 +349,8 @@ administrative boundaries.  PLoS ONE 15(4): e0231866.
   https://www.geoboundaries.org
 [geoBoundaries API]:
   https://www.geoboundaries.org/api.html
+[Keep a Changelog]:
+  https://keepachangelog.com/en/1.0.0/
 [MAAP Documentation Examples hosted on GitHub]:
   https://github.com/MAAP-Project/maap-documentation-examples.git
 [MAAP Documentation Examples hosted on GitLab]:

--- a/gedi-subset/algorithm_config.yaml
+++ b/gedi-subset/algorithm_config.yaml
@@ -1,6 +1,6 @@
 description: Subset GEDI L4A granules within an area of interest (AOI)
 algo_name: gedi-subset
-version: gedi-subset-0.2.2
+version: gedi-subset-0.2.3
 environment: ubuntu
 repository_url: https://repo.ops.maap-project.org/data-team/maap-documentation-examples.git
 docker_url: mas.maap-project.org:5000/root/ade-base-images/r:latest

--- a/gedi-subset/requirements-maappy.txt
+++ b/gedi-subset/requirements-maappy.txt
@@ -1,0 +1,3 @@
+# We're keeping this source dependency in this separate file to keep things DRY,
+# since this is referenced from multiple files.
+git+https://github.com/MAAP-Project/maap-py.git@hotfixes#egg=maappy

--- a/gedi-subset/requirements.txt
+++ b/gedi-subset/requirements.txt
@@ -7,4 +7,4 @@ pyarrow==8.0.0
 returns==0.19.0
 shapely==1.8.2
 typer==0.4.1
-git+https://github.com/MAAP-Project/maap-py.git@hotfixes#egg=maappy
+-r requirements-maappy.txt


### PR DESCRIPTION
Since conda lock files purposely do not handle source dependencies, the
DPS build script must install maap-py (from sources) separately from
dependencies specified in the lock file, until maap-py is properly
published to PyPI or conda-forge.

The pip source reference to maap-py was repeated in 3 files, but the
previous patch version of the gedi-subset algo only updated 2 of the 3
files, having missed the build.sh script. Therefore, this patch removes
the duplication in order to completely avoid such a miss in the future.