### PR TITLE
Fixed relative path in build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -24,7 +24,7 @@ esac
 conda create -y -n gedi_subset --file "${basedir}/gedi-subset/conda-${platform}-64.lock"
 
 # Install maap-py, since it cannot be specified in the lock file
-conda run --no-capture-output -n gedi_subset pip install -r gedi-subset/requirements-maappy.txt
+conda run --no-capture-output -n gedi_subset pip install -r maap-documentation-examples/gedi-subset/requirements-maappy.txt
 
 # Fail build if finicky mix of fiona and gdal isn't correct, so that we don't
 # have to wait to execute a DPS job to find out.

--- a/gedi-subset/CHANGELOG.md
+++ b/gedi-subset/CHANGELOG.md
@@ -7,7 +7,13 @@ variation of [Semantic Versioning], with the following difference: each version
 is prefixed with `gedi-subset-` (e.g., `gedi-subset-0.1.0`) to allow for
 distinct lines of versioning of independent work in sibling directories.
 
-## [gedi-subset-0.2.3] - 2022-08-03
+## [gedi-subset-0.2.4] - 2022-08-03
+
+### Fixed
+
+- `build.sh` now references the requirements-maappy in the correct relative path.
+
+## [gedi-subset-0.2.3] - 2022-08-03 [YANKED]
 
 ### Fixed
 

--- a/gedi-subset/algorithm_config.yaml
+++ b/gedi-subset/algorithm_config.yaml
@@ -1,6 +1,6 @@
 description: Subset GEDI L4A granules within an area of interest (AOI)
 algo_name: gedi-subset
-version: gedi-subset-0.2.3
+version: gedi-subset-0.2.4
 environment: ubuntu
 repository_url: https://repo.ops.maap-project.org/data-team/maap-documentation-examples.git
 docker_url: mas.maap-project.org:5000/root/ade-base-images/r:latest


### PR DESCRIPTION
`build.sh` now references the requirements-maappy in the correct relative path.