### PR TITLE
Fix path resolution for child build scripts

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -5,10 +5,10 @@ set -xeuo pipefail
 basedir=$(dirname "$(readlink -f "$0")")
 
 # Execute subdirectories' build scripts
-for subdir in $(ls -d */)
-do
-    file=${basedir}/${subdir}build.sh
-    if [ -f "$file" ]; then
-        bash $file
+for subdir in "${basedir}"/*/; do
+    build_script=${subdir}build.sh
+
+    if [ -f "${build_script}" ]; then
+        bash "${build_script}"
     fi
 done


### PR DESCRIPTION
When running the top level `build.sh` script from the root of the
repository, paths to the `build.sh` scripts in the immediate
sub-directories are resolved correctly. However, when the top level
build script was run from a different directory, such as the parent
directory of the repo root dir (which is what the DPS system does),
the paths to the child scripts were not resolved, and thus they were not
executed, effectively causing a "no-op" build. These paths are not
correctly resolved no matter what the current directory is when the
top level script is executed.

Fixes #24