### PR TITLE
fix(subset_beam): flattened h5py.Group to resolve error around BEAM subgroups

### DIFF
--- a/gedi-subset/CHANGELOG.md
+++ b/gedi-subset/CHANGELOG.md
@@ -7,17 +7,14 @@ variation of [Semantic Versioning], with the following difference: each version
 is prefixed with `gedi-subset-` (e.g., `gedi-subset-0.1.0`) to allow for
 distinct lines of versioning of independent work in sibling directories.
 
-## [gedi-subset-0.2.6] - 2022-09-14
+## [gedi-subset-0.2.6] - 2022-09-15
 
 ### Fixed
 
-- Resolves error where subset_beam was trying to generate a Series on BEAM subgroup instead of a dataset.
-- `datasets` function to return a flattened h5py.Group of one dimensional values
-- Issue [#31](https://github.com/MAAP-Project/maap-documentation-examples/issues/31) Running the gedi_subset algorithm (version 0.2.5) raises the following error after downloading a file and attempting to subset it: OSError: Can't read data (no appropriate function for conversion path).
-
-### Changed
-
-- Updated unit tests to include tests for subgroups and multidimensional datasets.
+- Issue [#31](https://github.com/MAAP-Project/maap-documentation-examples/issues/31)
+  Running the gedi_subset algorithm (version 0.2.5) raises the following error
+  after downloading a file and attempting to subset it: OSError: Can't read data
+  (no appropriate function for conversion path).
 
 ## [Unreleased]
 

--- a/gedi-subset/CHANGELOG.md
+++ b/gedi-subset/CHANGELOG.md
@@ -7,9 +7,21 @@ variation of [Semantic Versioning], with the following difference: each version
 is prefixed with `gedi-subset-` (e.g., `gedi-subset-0.1.0`) to allow for
 distinct lines of versioning of independent work in sibling directories.
 
+## [gedi-subset-0.2.6] - 2022-09-14
+
+### Fixed
+
+- Resolves error where subset_beam was trying to generate a Series on BEAM subgroup instead of a dataset.
+- `datasets` function to return a flattened h5py.Group of one dimensional values
+- Issue [#31](https://github.com/MAAP-Project/maap-documentation-examples/issues/31) Running the gedi_subset algorithm (version 0.2.5) raises the following error after downloading a file and attempting to subset it: OSError: Can't read data (no appropriate function for conversion path).
+
+### Changed
+
+- Updated unit tests to include tests for subgroups and multidimensional datasets.
+
 ## [Unreleased]
 
-## [gedi-subset-0.2.5] - 2022-09-13
+## [gedi-subset-0.2.5] - 2022-09-13 [YANKED]
 
 ### Fixed
 

--- a/gedi-subset/README.md
+++ b/gedi-subset/README.md
@@ -33,8 +33,6 @@ To run a GEDI subsetting DPS job, you must supply the following inputs:
   (**Default:**
   `agbd, agbd_se, l2_quality_flag, l4_quality_flag, sensitivity, sensitivity_a2`)
 - `query`: Query expression for subsetting the rows in the output file.
-  **IMPORTANT:** The `columns` input must contain at least all of the columns
-  that appear in this query expression, otherwise an error will occur.
   (**Default:** `l2_quality_flag == 1 and l4_quality_flag == 1 and sensitivity >
   0.95 and sensitivity_a2 > 0.95"`)
 - `limit`: Maximum number of GEDI granule data files to download (among those

--- a/gedi-subset/algorithm_config.yaml
+++ b/gedi-subset/algorithm_config.yaml
@@ -1,6 +1,6 @@
 description: Subset GEDI L4A granules within an area of interest (AOI)
 algo_name: gedi-subset
-version: gedi-subset-0.2.5
+version: gedi-subset-0.2.6
 environment: ubuntu
 repository_url: https://repo.ops.maap-project.org/data-team/maap-documentation-examples.git
 docker_url: mas.maap-project.org:5000/root/ade-base-images/r:latest

--- a/gedi-subset/src/gedi_subset/gedi_utils.py
+++ b/gedi-subset/src/gedi_subset/gedi_utils.py
@@ -3,8 +3,8 @@ import logging
 import os
 import os.path
 import warnings
-from typing import Any, Callable, Iterable, Mapping, TypeVar, Union
 from itertools import chain
+from typing import Any, Callable, Iterable, Mapping, TypeVar, Union
 
 import h5py
 import numpy as np
@@ -163,8 +163,7 @@ def subset_hdf5(
     fall within the specified area of interest (AOI) and also satisfy the specified
     query criteria.  The resulting ``geopandas.GeoDataFrame`` is further reduced to
     including only the specified columns, which must be names of datasets within the
-    top-level groups of the HDF5 file (and more specifically, only to groups named with
-    the prefix `"BEAM"`).
+    HDF5 file (and more specifically, only to groups named with the prefix `"BEAM"`).
 
     To illustrate, assume an HDF5 file (`hdf5`) structured like so (values are for
     illustration purposes only):
@@ -205,7 +204,7 @@ def subset_hdf5(
 
     Assumptions:
 
-    - The top-level groups in the HDF5 file are named with the prefix `"BEAM"`, and the
+    - The HDF5 file contains groups that are named with the prefix `"BEAM"`, and the
       suffix is parseable as an integer.
     - Every `"BEAM*"` group contains datasets named `lat_lowestmode` and
       `lon_lowestmode`, representing the latitude and longitude, respectively, which are
@@ -228,7 +227,7 @@ def subset_hdf5(
         datasets of each `"BEAM*"` group within the HDF5 file.
     columns : Iterable[str]
         Column names to be included in the subset.  The specified column names must
-        match dataset names within the top-level `"BEAM*"` groups of the HDF5 file.
+        match dataset names within the `"BEAM*"` groups of the HDF5 file.
         Although the `query` expression may include column names not given in this
         iterable of names, the resulting ``GeoDataFrame`` will contain only the columns
         specified by this parameter, along with `filename` (str) and `BEAM` (int)
@@ -346,7 +345,9 @@ def subset_hdf5(
     """
 
     def datasets(group: h5py.Group) -> Iterable[h5py.Dataset]:
-        """Returns a flattened h5py.Group of one dimensional values"""
+        """Return an iterable of all 1-dimensional ``h5py.Dataset``s from all levels
+        within an ``h5py.Group``.
+        """
         return chain.from_iterable(
             datasets(value)
             if isinstance(value, h5py.Group)

--- a/gedi-subset/tests/conftest.py
+++ b/gedi-subset/tests/conftest.py
@@ -84,6 +84,11 @@ def h5_path(tmp_path_factory: pytest.TempPathFactory) -> str:
         beam.create_dataset("lat_lowestmode", data=[-1.82556, -9.82514, -1.82471])
         beam.create_dataset("lon_lowestmode", data=[12.06648, 12.06678, 12.06707])
         beam.create_dataset("sensitivity", data=[0.9, 0.97, 0.99], dtype="f4")
+        land_cover = beam.create_group("land_cover_data")
+        land_cover.create_dataset("landsat_treecover", data=[77.0, 98.0, 95.0])
+        land_cover.create_dataset(
+            "x_var", data=[[10.0, 15.0, 20.0], [10.0, 15.0, 20.0]]
+        )
 
         beam = h5_file.create_group("BEAM0001")
         beam.create_dataset("agbd", data=[1.1715966, 1.630395, 3.5265787], dtype="f4")
@@ -93,5 +98,10 @@ def h5_path(tmp_path_factory: pytest.TempPathFactory) -> str:
         beam.create_dataset("lat_lowestmode", data=[-1.82556, -9.82514, -1.82471])
         beam.create_dataset("lon_lowestmode", data=[12.06648, 12.06678, 12.06707])
         beam.create_dataset("sensitivity", data=[0.93, 0.96, 0.98], dtype="f4")
+        land_cover = beam.create_group("land_cover_data")
+        land_cover.create_dataset("landsat_treecover", data=[68.0, 85.0, 83.0])
+        land_cover.create_dataset(
+            "x_var", data=[[15.0, 20.0, 25.0], [15.0, 20.0, 25.0]]
+        )
 
     return str(path)

--- a/gedi-subset/tests/test_gedi_utils.py
+++ b/gedi-subset/tests/test_gedi_utils.py
@@ -24,6 +24,7 @@ def fixture_path(filename: str) -> str:
         ({"sensitivity", "agbd"}, "agbd > 1 and l2_quality_flag == 1", 2),
         ({"sensitivity", "agbd", "agbd_se"}, "agbd_se > 3", 3),
         ({"agbd", "lat_lowestmode", "lon_lowestmode"}, "sensitivity >= 0.9", 4),
+        ({"landsat_treecover"}, "landsat_treecover > 60.0", 4),
     ],
 )
 def test_subset_hdf5(


### PR DESCRIPTION
gedi_subset: OSError: Can't read data (no appropriate function for conversion path) #31 

Resolves error where subset_beam was trying to generate a Series on BEAM subgroup instead of a dataset. Accomplished by flattening out the subgroups to return one-dimensional datasets.


Fix:
- [fix(subset_beam): flattened h5py.Group to resolve error around BEAM subgroups](https://github.com/MAAP-Project/maap-documentation-examples/pull/32/commits/e17b9436f2fdb952807cc128c83700ea1bf348e8)

Docs:
- [docs(CHANGELOG/README): Updated docs to bump algorithm version](https://github.com/MAAP-Project/maap-documentation-examples/pull/32/commits/0e443c7b5c93f2cab69369b3a616a8b8bcb357e1)
