### PR TITLE
fix(gedi_subset): out of memory error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
+.envrc
 maap.cfg
+fil-result/
 input/
 output/
 

--- a/gedi-subset/CHANGELOG.md
+++ b/gedi-subset/CHANGELOG.md
@@ -7,7 +7,23 @@ variation of [Semantic Versioning], with the following difference: each version
 is prefixed with `gedi-subset-` (e.g., `gedi-subset-0.1.0`) to allow for
 distinct lines of versioning of independent work in sibling directories.
 
-## [gedi-subset-0.2.6] - 2022-09-15
+## [Unreleased]
+
+## [gedi-subset-0.2.7] - 2022-09-27
+
+Hotfix replacement for `gedi-subset-0.2.6`, which was yanked because it caused
+jobs with larger `.h5` files to run out of memory, particularly for subsetting
+GEDI L2A data.
+
+## Fixed
+
+- Issue [#34](https://github.com/MAAP-Project/maap-documentation-examples/issues/34)
+  Fixes out of memory bug introduced by previous bug fix.
+
+## [gedi-subset-0.2.6] - 2022-09-15 [YANKED]
+
+Hotfix replacement for `gedi-subset-0.2.5`, which was yanked because it caused
+every job execution to fail.
 
 ### Fixed
 
@@ -15,8 +31,6 @@ distinct lines of versioning of independent work in sibling directories.
   Running the gedi_subset algorithm (version 0.2.5) raises the following error
   after downloading a file and attempting to subset it: OSError: Can't read data
   (no appropriate function for conversion path).
-
-## [Unreleased]
 
 ## [gedi-subset-0.2.5] - 2022-09-13 [YANKED]
 
@@ -32,9 +46,13 @@ distinct lines of versioning of independent work in sibling directories.
 
 ## [gedi-subset-0.2.4] - 2022-08-03
 
+Hotfix replacement for `gedi-subset-0.2.3`, which was yanked, as it caused
+algorithm registration to fail.
+
 ### Fixed
 
-- `build.sh` now references the requirements-maappy in the correct relative path.
+- `build.sh` now references the requirements-maappy in the correct relative path
+  to allow algorithm registration to succeed.
 
 ## [gedi-subset-0.2.3] - 2022-08-03 [YANKED]
 

--- a/gedi-subset/algorithm_config.yaml
+++ b/gedi-subset/algorithm_config.yaml
@@ -1,6 +1,6 @@
 description: Subset GEDI L4A granules within an area of interest (AOI)
 algo_name: gedi-subset
-version: gedi-subset-0.2.6
+version: gedi-subset-0.2.7
 environment: ubuntu
 repository_url: https://repo.ops.maap-project.org/data-team/maap-documentation-examples.git
 docker_url: mas.maap-project.org:5000/root/ade-base-images/r:latest

--- a/gedi-subset/environment/environment-dev.yml
+++ b/gedi-subset/environment/environment-dev.yml
@@ -20,7 +20,10 @@ dependencies:
   # - mypy=0.950
   - mypy=0.971
   - pandas-stubs
+  - pip
   - pre-commit=2.20.0
   - pytest=7.1.3
   - types-cachetools=5.2.1
   - types-requests=2.28.9
+  - pip:
+    - filprofiler==2022.9.1


### PR DESCRIPTION
Minimize memory consumption during subsetting, while also avoiding requiring the user to include all columns in the output that are referenced in the query expression.

Further:

- Add `filprofiler` as a dev dependency for memory profiling
- Remove unused functions `converge` and `append_message`

Fixes #34