### PR TITLE
Add notebook that plots the boundaries of STAC items from a STAC search with lonboard

### DIFF
--- a/stac_spatial_coverage/notebooks/plot_items.ipynb
+++ b/stac_spatial_coverage/notebooks/plot_items.ipynb
@@ -14,7 +14,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 146,
+   "execution_count": 1,
    "id": "54667261-2cd2-46b3-a3fd-8b15b31e8bb1",
    "metadata": {
     "tags": []
@@ -29,7 +29,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 147,
+   "execution_count": 2,
    "id": "e066c145-5b88-4535-b30f-198a2de8f6ff",
    "metadata": {
     "tags": []
@@ -42,7 +42,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 148,
+   "execution_count": 3,
    "id": "a40394ce-0a3e-4fcc-846e-1115f41dd7b7",
    "metadata": {
     "tags": []
@@ -57,7 +57,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 149,
+   "execution_count": 4,
    "id": "cf376450-e551-4e91-9511-7fe7fcdbbee1",
    "metadata": {
     "tags": []
@@ -69,7 +69,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 150,
+   "execution_count": 5,
    "id": "dbbbafc8-62a5-4235-a9be-fd87ad13ff02",
    "metadata": {
     "tags": []
@@ -82,7 +82,35 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 151,
+   "execution_count": 6,
+   "id": "f2035d8e-fba9-40f5-9251-14b25d533b4e",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'geometry': {'type': 'Polygon',\n",
+       "  'coordinates': [[[-8.338351614014996, 60.5680161920192],\n",
+       "    [-8.653367372629132, 60.46746117664409],\n",
+       "    [-8.417737394132065, 60.298102993955844],\n",
+       "    [-8.103645691853226, 60.39813807692636],\n",
+       "    [-8.338351614014996, 60.5680161920192]]]}}"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "items_as_dicts[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
    "id": "9efc2628-7a26-4b8d-b9f2-e3c475341124",
    "metadata": {
     "tags": []
@@ -95,7 +123,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 152,
+   "execution_count": 8,
    "id": "90442822-847e-48d2-bb01-401291468a25",
    "metadata": {
     "tags": []
@@ -104,7 +132,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "c16325d4f26a4e568ba433e611d10d14",
+       "model_id": "dfb0b96014fb470ca0875761ff17320e",
        "version_major": 2,
        "version_minor": 0
       },
@@ -113,7 +141,7 @@
        "geometry: list<item: list<item: fixed_size_list<item: double…"
       ]
      },
-     "execution_count": 152,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/stac_spatial_coverage/notebooks/plot_items.ipynb
+++ b/stac_spatial_coverage/notebooks/plot_items.ipynb
@@ -1,0 +1,147 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "f325fd86-7157-4529-a614-220c5db7ba46",
+   "metadata": {},
+   "source": [
+    "### Plotting spatial coverage of a STAC collection of rasters with lonboard.\n",
+    "\n",
+    "run this notebook in the base environment of a pangeo workspace.\n",
+    "run the following line, restart your kernel and then refresh this browser page before proceeding.\n",
+    "```! pip install lonboard pystac-client```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 146,
+   "id": "54667261-2cd2-46b3-a3fd-8b15b31e8bb1",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "from pystac_client import ItemSearch\n",
+    "import geopandas as gpd\n",
+    "from shapely.geometry import shape\n",
+    "import lonboard"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 147,
+   "id": "e066c145-5b88-4535-b30f-198a2de8f6ff",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "stac_endpoint = 'https://stac.dit.maap-project.org' # STAC test (\"dit\") catalog\n",
+    "collection_id = 'tri_seasonal_s1_sar_composites' # Collection name in the catalog"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 148,
+   "id": "a40394ce-0a3e-4fcc-846e-1115f41dd7b7",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# we only want the geometries\n",
+    "exclude_fields = ['assets','bbox', 'id', 'links', 'collection','properties', 'stac_version','stac_extensions', 'type']\n",
+    "# return only N items\n",
+    "limit = 1000"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 149,
+   "id": "cf376450-e551-4e91-9511-7fe7fcdbbee1",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "search = ItemSearch(f'https://stac.dit.maap-project.org/search', collections=[collection_id], fields={'exclude':exclude_fields},limit=limit)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 150,
+   "id": "dbbbafc8-62a5-4235-a9be-fd87ad13ff02",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# actually execute the search and turn the result into a list of dicts\n",
+    "items_as_dicts = [i for i in search.items_as_dicts()]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 151,
+   "id": "9efc2628-7a26-4b8d-b9f2-e3c475341124",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# turn that into a geopandas dataframe\n",
+    "df = gpd.GeoDataFrame(geometry=[shape(item['geometry']) for item in items_as_dicts])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 152,
+   "id": "90442822-847e-48d2-bb01-401291468a25",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "c16325d4f26a4e568ba433e611d10d14",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map(layers=[SolidPolygonLayer(table=pyarrow.Table\n",
+       "geometry: list<item: list<item: fixed_size_list<item: double…"
+      ]
+     },
+     "execution_count": 152,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "lonboard.viz(df)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/stac_spatial_coverage/notebooks/plot_items.ipynb
+++ b/stac_spatial_coverage/notebooks/plot_items.ipynb
@@ -8,7 +8,7 @@
     "### Plotting spatial coverage of a STAC collection of rasters with lonboard.\n",
     "\n",
     "run this notebook in the base environment of a pangeo workspace.\n",
-    "run the following line, restart your kernel and then refresh this browser page before proceeding.\n",
+    "run the following line, **restart your kernel and then refresh this browser page before proceeding. This is necessary for lonboard to work as of now.**\n",
     "```! pip install lonboard pystac-client```"
    ]
   },


### PR DESCRIPTION
Ref issue : https://github.com/NASA-IMPACT/active-maap-sprint/issues/798. In this notebook, I : 

- query the test STAC catalog to get geometries of the STAC items from a given collection
- I turn the list of geometries into a geopandas dataframe
- I plot this with lonboard

The idea is to show an example of this kind of task for a large collection. 

Things to change in the notebook : 

- Color of the mapping
- Is there a way to see which item a given box corresponds to on the map ? I'd have to not drop the id in that case.
- Full collection search (right now the DB is very small so it can't handle a full search, collection size is 350k items. Probably need to switch to dev DB). 