### PR TITLE
update version metadata for the icesat2-boreal collection

### DIFF
--- a/icesat2-boreal/icesat2-boreal-stac-version-update.ipynb
+++ b/icesat2-boreal/icesat2-boreal-stac-version-update.ipynb
@@ -1,0 +1,327 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9859499b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# /// script\n",
+    "# requires-python = \">=3.13\"\n",
+    "# dependencies = [\n",
+    "#     \"boto3\",\n",
+    "#     \"httpx\",\n",
+    "#     \"pystac-client\",\n",
+    "# ]\n",
+    "# ///"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "20353fd0-40ad-41a8-9ff7-44dd6cd37433",
+   "metadata": {},
+   "source": [
+    "# Update version metadata in the original icesat2-boreal collection\n",
+    "\n",
+    "The goal is to add a `deprecated` tag to the collection metadata and provide a link to the latest version (icesat2-boreal-v2.1-agb)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "d6720692-0b57-4498-8dc7-a0e5cba0cd45",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "\n",
+    "import boto3\n",
+    "import httpx\n",
+    "import pystac\n",
+    "import pystac_client\n",
+    "from pystac.extensions.version import VersionRelType\n",
+    "\n",
+    "\n",
+    "pystac.set_stac_version(\"1.0.0\")\n",
+    "\n",
+    "\n",
+    "COLLECTION_ID = \"icesat2-boreal\"\n",
+    "VERSION = \"v1.0\"\n",
+    "\n",
+    "# STAC ingestory URL\n",
+    "INGESTOR_URL = \"https://stac-ingestor.maap-project.org\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "95568e9a-adaf-4354-8b7c-aea61689600a",
+   "metadata": {},
+   "source": [
+    "## Step 1: get token for STAC ingestor API\n",
+    "This needs to be run with credentials for the SMCE MAAP AWS account set in the environment."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "a7a51de1-8475-4ec2-be48-811ef43c89c2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# paste MAAP SMCE AWS credentials here:\n",
+    "session = boto3.Session(\n",
+    "    region_name=\"us-west-2\",\n",
+    ")\n",
+    "client = session.client(\"secretsmanager\", region_name=\"us-west-2\")\n",
+    "\n",
+    "# MAAP STAC secret\n",
+    "response = client.get_secret_value(\n",
+    "    SecretId=\"arn:aws:secretsmanager:us-west-2:916098889494:secret:MAAP-STAC-auth-dev/MAAP-workflows-EsykqB\"\n",
+    ")\n",
+    "\n",
+    "settings = json.loads(response[\"SecretString\"])\n",
+    "\n",
+    "# function to get token for STAC ingestor\n",
+    "def get_token(\n",
+    "    client_id: str, \n",
+    "    client_secret: str, \n",
+    "    domain: str,\n",
+    "    scope: str\n",
+    ") -> str:\n",
+    "    response = httpx.post(\n",
+    "        f\"{domain}/oauth2/token\",\n",
+    "        headers={\n",
+    "            \"Content-Type\": \"application/x-www-form-urlencoded\",\n",
+    "        },\n",
+    "        auth=(client_id, client_secret),\n",
+    "        data={\n",
+    "            \"grant_type\": \"client_credentials\",\n",
+    "            \"scope\": scope,\n",
+    "        },\n",
+    "    )\n",
+    "    try:\n",
+    "        response.raise_for_status()\n",
+    "    except Exception:\n",
+    "        raise\n",
+    "\n",
+    "    return response.json()[\"access_token\"]\n",
+    "\n",
+    "\n",
+    "token = get_token(\n",
+    "    client_id = settings[\"client_id\"],\n",
+    "    client_secret = settings[\"client_secret\"],\n",
+    "    domain = settings[\"cognito_domain\"],\n",
+    "    scope = settings[\"scope\"],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e1a0edc9-21a6-4495-aa06-707f6887d1e6",
+   "metadata": {},
+   "source": [
+    "## Step 2: retrieve the collection from the catalog"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "8f23034a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "client = pystac_client.Client.open(\"https://stac.maap-project.org\")\n",
+    "collection = client.get_collection(COLLECTION_ID)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7230e263-5f84-495b-ae96-efc6044e932d",
+   "metadata": {},
+   "source": [
+    "## Step 3: add the version metadata\n",
+    "1. tag as v1.0\n",
+    "2. add link to latest version of the collection"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "d4b202bc-57ed-42f4-9720-6ddc2f9d05b7",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\n",
+      "  \"type\": \"Collection\",\n",
+      "  \"id\": \"icesat2-boreal\",\n",
+      "  \"stac_version\": \"1.0.0\",\n",
+      "  \"description\": \"Aboveground biomass density c.2020 gridded to 30m derived from ICESat-2, Harmonized Landsat-Sentinel2 and Copernicus DEM. Band 1 is the data band. Band 2 is the standard deviation.\",\n",
+      "  \"links\": [\n",
+      "    {\n",
+      "      \"rel\": \"root\",\n",
+      "      \"href\": \"https://stac.maap-project.org\",\n",
+      "      \"type\": \"application/json\",\n",
+      "      \"title\": \"MAAP STAC API (dev)\"\n",
+      "    },\n",
+      "    {\n",
+      "      \"rel\": \"latest-version\",\n",
+      "      \"href\": \"https://stac.maap-project.org/collections/icesat2-boreal-v2.1-agb\",\n",
+      "      \"title\": \"version 2.1 (biomass)\"\n",
+      "    }\n",
+      "  ],\n",
+      "  \"stac_extensions\": [\n",
+      "    \"https://stac-extensions.github.io/render/v1.0.0/schema.json\",\n",
+      "    \"https://stac-extensions.github.io/item-assets/v1.0.0/schema.json\",\n",
+      "    \"https://stac-extensions.github.io/version/v1.2.0/schema.json\"\n",
+      "  ],\n",
+      "  \"renders\": {\n",
+      "    \"agb\": {\n",
+      "      \"bidx\": [\n",
+      "        1\n",
+      "      ],\n",
+      "      \"title\": \"ICESat-2 Boreal Biomass\",\n",
+      "      \"assets\": [\n",
+      "        \"tif\"\n",
+      "      ],\n",
+      "      \"nodata\": \"nan\",\n",
+      "      \"rescale\": [\n",
+      "        [\n",
+      "          0,\n",
+      "          400\n",
+      "        ]\n",
+      "      ],\n",
+      "      \"colormap_name\": \"gist_earth_r\"\n",
+      "    }\n",
+      "  },\n",
+      "  \"item_assets\": {\n",
+      "    \"csv\": {\n",
+      "      \"type\": \"text/csv\",\n",
+      "      \"roles\": [\n",
+      "        \"data\"\n",
+      "      ],\n",
+      "      \"title\": \"CSV\",\n",
+      "      \"description\": \"CSV of training data\"\n",
+      "    },\n",
+      "    \"tif\": {\n",
+      "      \"type\": \"image/tiff; application=geotiff; profile=cloud-optimized\",\n",
+      "      \"roles\": [\n",
+      "        \"data\",\n",
+      "        \"layer\"\n",
+      "      ],\n",
+      "      \"title\": \"Cloud Optimized GeoTIFF of boreal data\",\n",
+      "      \"description\": \"Cloud Optimized GeoTIFF of boreal data\"\n",
+      "    }\n",
+      "  },\n",
+      "  \"version\": \"v1.0\",\n",
+      "  \"deprecated\": true,\n",
+      "  \"title\": \"Gridded Boreal Aboveground Biomass Density c.2020 at 30m resolution\",\n",
+      "  \"extent\": {\n",
+      "    \"spatial\": {\n",
+      "      \"bbox\": [\n",
+      "        [\n",
+      "          -180.0,\n",
+      "          51.6,\n",
+      "          180.0,\n",
+      "          78.0\n",
+      "        ]\n",
+      "      ]\n",
+      "    },\n",
+      "    \"temporal\": {\n",
+      "      \"interval\": [\n",
+      "        [\n",
+      "          \"2019-01-01T00:00:00Z\",\n",
+      "          \"2021-01-01T00:00:00Z\"\n",
+      "        ]\n",
+      "      ]\n",
+      "    }\n",
+      "  },\n",
+      "  \"license\": \"CC-BY\"\n",
+      "}\n"
+     ]
+    }
+   ],
+   "source": [
+    "# add version info\n",
+    "collection.ext.add(\"version\")\n",
+    "collection.ext.version.version = VERSION\n",
+    "collection.ext.version.deprecated = True\n",
+    "\n",
+    "# clean up links (because pgstac will add them automatically)\n",
+    "collection.links = [link for link in collection.links if link.rel == \"root\"]\n",
+    "collection.add_links(\n",
+    "    [\n",
+    "        pystac.Link(\n",
+    "            rel=VersionRelType.LATEST,\n",
+    "            target=\"https://stac.maap-project.org/collections/icesat2-boreal-v2.1-agb\",\n",
+    "            title=\"version 2.1 (biomass)\",\n",
+    "        ),\n",
+    "    ]\n",
+    ")\n",
+    "\n",
+    "\n",
+    "print(\n",
+    "    json.dumps(collection.to_dict(), indent=2)\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c40824e3-0380-4bba-9699-9946958374ba",
+   "metadata": {},
+   "source": [
+    "## Step 4: Post to the STAC ingestor API"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "c0396317-defd-4413-be46-6d02787f0312",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['Successfully published: icesat2-boreal']\n"
+     ]
+    }
+   ],
+   "source": [
+    "post_annual = httpx.post(\n",
+    "    f\"{INGESTOR_URL}/collections\",\n",
+    "    json=collection.to_dict(),\n",
+    "    headers = {\n",
+    "        'Authorization': f'Bearer {token}',\n",
+    "        'Content-Type': 'application/json',  # Assuming you are sending JSON data\n",
+    "    }\n",
+    ")\n",
+    "print(post_annual.json())"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Handling this manually is simpler because we don't have the stactools-pipeline code for the original collection.