### PR TITLE
add scripts/notebooks for generating/loading icesat2-boreal-v2.1

### DIFF
--- a/icesat2-boreal/README.md
+++ b/icesat2-boreal/README.md
@@ -1,0 +1,10 @@
+# ICESat-2 Boreal
+
+Since we do not have the permanent event-based infrastructure set up for item creation and ingestion, we are managing STAC metadata more manually.
+
+## STAC Item generation
+
+1. Run item-gen.py with: `uv run -p 3.13 item-gen.py`
+    - this will use a coiled cluster to generate 9900 STAC items and write them to a ndjson file in S3
+2. Execute item-load.ipynb
+    - this will create the collection JSON documents, post them to the ingestor API, then load the items from the ndjson and post them to the ingestor API

--- a/icesat2-boreal/item-gen.py
+++ b/icesat2-boreal/item-gen.py
@@ -1,0 +1,111 @@
+# /// script
+# requires-python = ">=3.13"
+# dependencies = [
+#     "boto3",
+#     "coiled",
+#     "icesat2-boreal-stac",
+#     "smart-open",
+#     "tqdm",
+# ]
+#
+# [tool.uv.sources]
+# icesat2-boreal-stac = { git = "https://github.com/MAAP-project/icesat2-boreal-stac.git", rev = "0.2.3" }
+# ///
+
+import json
+import logging
+import re
+from typing import Any, Dict, List
+from urllib.parse import urlparse
+
+import boto3
+import coiled
+import smart_open
+from icesat2_boreal_stac.stac import create_item
+
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
+)
+logging.getLogger("boto3").setLevel(logging.WARNING)
+logging.getLogger("botocore").setLevel(logging.WARNING)
+logger = logging.getLogger(__name__)
+
+S3_ASSET_PATH = "s3://nasa-maap-data-store/file-staging/nasa-map/icesat2-boreal-v2.1/"
+ITEMS_NDJSON_KEY = (
+    "s3://maap-ops-workspace/henrydevseed/icesat2-boreal-v2.1/items.ndjson"
+)
+
+
+def scan_s3_files(bucket: str, prefix: str, filename_regex: str) -> List[str]:
+    """Scan S3 bucket for files matching the given regex pattern within specified prefix."""
+    s3_client = boto3.client("s3")
+    matching_files = []
+    paginator = s3_client.get_paginator("list_objects_v2")
+
+    for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
+        if "Contents" not in page:
+            continue
+
+        # Check each object against the regex pattern
+        for obj in page["Contents"]:
+            key = obj["Key"]
+            if re.match(
+                filename_regex, key.split("/")[-1]
+            ):  # Match against filename only
+                matching_files.append(f"s3://{bucket}/{key}")
+
+    return matching_files
+
+
+@coiled.function(region="us-west-2", threads_per_worker=-1, n_workers=[0, 100])
+def _create_item(key: str) -> Dict[str, Any]:
+    item = create_item(key)
+    variable = "ht" if item.id.startswith("boreal_ht") else "agb"
+    item_dict = item.to_dict()
+    item_dict["collection"] = f"icesat2-boreal-v2.1-{variable}"
+
+    return item_dict
+
+
+def write_ndjson(items: List[Dict[str, Any]], ndjson_key: str) -> None:
+    s3_client = boto3.client("s3")
+    with smart_open.open(
+        ndjson_key,
+        "wt",
+        encoding="utf-8",
+        transport_params={"client": s3_client},
+    ) as fout:
+        count = 0
+        for item in items:
+            fout.write(json.dumps(item) + "\n")
+            count += 1
+
+    logger.info(f"wrote {count} items to {ndjson_key}")
+
+
+def main():
+    # Parse S3 path
+    s3_url = urlparse(S3_ASSET_PATH)
+
+    bucket = s3_url.netloc
+    prefix = s3_url.path.lstrip("/")
+    print("scanning for matching files in S3")
+    inventory = scan_s3_files(
+        bucket=bucket,
+        prefix=prefix,
+        filename_regex=r".*\.tif$",
+    )
+
+    logger.info(f"found {len(inventory)} files")
+    with open("/tmp/inventory.txt", "w") as f:
+        for key in inventory:
+            f.write(key + "\n")
+
+    logger.info("generating item metadata")
+    _items = _create_item.map(inventory)
+
+    write_ndjson(_items, ndjson_key=ITEMS_NDJSON_KEY)
+
+
+if __name__ == "__main__":
+    main()

--- a/icesat2-boreal/item-load.ipynb
+++ b/icesat2-boreal/item-load.ipynb
@@ -1,0 +1,291 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "237e6ee8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# /// script\n",
+    "# requires-python = \">=3.13\"\n",
+    "# dependencies = [\n",
+    "#     \"icesat2-boreal-stac\",\n",
+    "#     \"smart-open\",\n",
+    "#     \"tqdm\",\n",
+    "# ]\n",
+    "#\n",
+    "# [tool.uv.sources]\n",
+    "# icesat2-boreal-stac = { git = \"https://github.com/MAAP-project/icesat2-boreal-stac.git\", rev = \"0.2.3\" }\n",
+    "# ///"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "20353fd0-40ad-41a8-9ff7-44dd6cd37433",
+   "metadata": {},
+   "source": [
+    "# Update version metadata in the original icesat2-boreal collection\n",
+    "\n",
+    "The goal is to add a `deprecated` tag to the collection metadata and provide a link to the latest version (icesat2-boreal-v2.1-agb).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d6720692-0b57-4498-8dc7-a0e5cba0cd45",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import asyncio\n",
+    "import json\n",
+    "from typing import Any, Dict, List\n",
+    "\n",
+    "import boto3\n",
+    "import httpx\n",
+    "import pystac\n",
+    "import smart_open\n",
+    "import tqdm\n",
+    "\n",
+    "from icesat2_boreal_stac.stac import create_collection, Variable\n",
+    "\n",
+    "pystac.set_stac_version(\"1.1.0\")\n",
+    "\n",
+    "# STAC ingestor URL\n",
+    "INGESTOR_URL = \"https://stac-ingestor.maap-project.org\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "95568e9a-adaf-4354-8b7c-aea61689600a",
+   "metadata": {},
+   "source": [
+    "## Step 1: get token for STAC ingestor API\n",
+    "This needs to be run with credentials for the SMCE MAAP AWS account set in the environment.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a7a51de1-8475-4ec2-be48-811ef43c89c2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# paste MAAP SMCE AWS credentials here:\n",
+    "session = boto3.Session(\n",
+    "    region_name=\"us-west-2\",\n",
+    ")\n",
+    "client = session.client(\"secretsmanager\", region_name=\"us-west-2\")\n",
+    "\n",
+    "# MAAP STAC secret\n",
+    "response = client.get_secret_value(\n",
+    "    SecretId=\"arn:aws:secretsmanager:us-west-2:916098889494:secret:MAAP-STAC-auth-dev/MAAP-workflows-EsykqB\"\n",
+    ")\n",
+    "\n",
+    "settings = json.loads(response[\"SecretString\"])\n",
+    "\n",
+    "# function to get token for STAC ingestor\n",
+    "def get_token(\n",
+    "    client_id: str, \n",
+    "    client_secret: str, \n",
+    "    domain: str,\n",
+    "    scope: str\n",
+    ") -> str:\n",
+    "    response = httpx.post(\n",
+    "        f\"{domain}/oauth2/token\",\n",
+    "        headers={\n",
+    "            \"Content-Type\": \"application/x-www-form-urlencoded\",\n",
+    "        },\n",
+    "        auth=(client_id, client_secret),\n",
+    "        data={\n",
+    "            \"grant_type\": \"client_credentials\",\n",
+    "            \"scope\": scope,\n",
+    "        },\n",
+    "    )\n",
+    "    try:\n",
+    "        response.raise_for_status()\n",
+    "    except Exception:\n",
+    "        raise\n",
+    "\n",
+    "    return response.json()[\"access_token\"]\n",
+    "\n",
+    "\n",
+    "token = get_token(\n",
+    "    client_id = settings[\"client_id\"],\n",
+    "    client_secret = settings[\"client_secret\"],\n",
+    "    domain = settings[\"cognito_domain\"],\n",
+    "    scope = settings[\"scope\"],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7230e263-5f84-495b-ae96-efc6044e932d",
+   "metadata": {},
+   "source": [
+    "## Step 2: create the collection objects\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d4b202bc-57ed-42f4-9720-6ddc2f9d05b7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "agb_collection = create_collection(Variable.AGB)\n",
+    "ht_collection = create_collection(Variable.HT)\n",
+    "\n",
+    "print(\n",
+    "    json.dumps(agb_collection.to_dict(), indent=2)\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c40824e3-0380-4bba-9699-9946958374ba",
+   "metadata": {},
+   "source": [
+    "## Step 3: Post collections to the STAC ingestor API"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c0396317-defd-4413-be46-6d02787f0312",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "post_agb = httpx.post(\n",
+    "    f\"{INGESTOR_URL}/collections\",\n",
+    "    json=agb_collection.to_dict(),\n",
+    "    headers = {\n",
+    "        'Authorization': f'Bearer {token}',\n",
+    "        'Content-Type': 'application/json',  # Assuming you are sending JSON data\n",
+    "    },\n",
+    "    timeout=None,\n",
+    ")\n",
+    "print(post_agb.json())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f49e6190-4d64-4771-b3b9-6073a29b2e0e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "post_ht = httpx.post(\n",
+    "    f\"{INGESTOR_URL}/collections\",\n",
+    "    json=ht_collection.to_dict(),\n",
+    "    headers = {\n",
+    "        'Authorization': f'Bearer {token}',\n",
+    "        'Content-Type': 'application/json',  # Assuming you are sending JSON data\n",
+    "    },\n",
+    "    timeout=None,\n",
+    ")\n",
+    "print(post_ht.json())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0d392d61-54a3-4860-a93d-71f10592afde",
+   "metadata": {},
+   "source": [
+    "## Step 4: Load items to the ingestor API\n",
+    "\n",
+    "The items were generated in a [separate process](./item-gen.py) and added to a ndjson file."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a4b440ae-f09b-4ecd-91ff-4a91c46eb7ad",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ndjson_key = \"s3://maap-ops-workspace/henrydevseed/icesat2-boreal-v2.1/items.ndjson\"\n",
+    "\n",
+    "with smart_open.open(ndjson_key) as src:\n",
+    "    items = [json.loads(line) for line in src]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "caa11058-4e7a-4ea7-9c2c-6da8f6c10a49",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def post_item(client: httpx.AsyncClient, item: Dict[str, Any], token: str) -> None:\n",
+    "    \"\"\"Post a single item to the STAC ingestor API\"\"\"\n",
+    "    try:\n",
+    "        response = await client.post(\n",
+    "            f\"{INGESTOR_URL}/ingestions\",\n",
+    "            json=item,\n",
+    "            headers={\n",
+    "                'Authorization': f'Bearer {token}',\n",
+    "                'Content-Type': 'application/json',\n",
+    "            },\n",
+    "        )\n",
+    "        response.raise_for_status()\n",
+    "    except Exception as e:\n",
+    "        print(f\"Error posting item: {e}\")\n",
+    "        raise\n",
+    "\n",
+    "async def post_all_items(items: List, token: str, max_concurrent: int = 20) -> None:\n",
+    "    \"\"\"Post all items concurrently with a limit on concurrent requests\"\"\"\n",
+    "    async with httpx.AsyncClient(timeout=60) as client:\n",
+    "        semaphore = asyncio.Semaphore(max_concurrent)\n",
+    "        \n",
+    "        async def bounded_post(item):\n",
+    "            async with semaphore:\n",
+    "                return await post_item(client, item, token)\n",
+    "        \n",
+    "        tasks = [bounded_post(item) for item in items]\n",
+    "        \n",
+    "        for task in tqdm.tqdm(asyncio.as_completed(tasks), total=len(tasks)):\n",
+    "            await task\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "85d1cda3-5eb3-4314-97d2-1d66ec6c6609",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "await post_all_items(items, token)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "40db6554-a86f-4a8f-977a-bc2b0687dec6",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
After resolving the changes required from https://github.com/MAAP-Project/icesat2-boreal-stac/issues/3 we need to update the STAC metadata for these collections!

We were doing this in stactools-pipelines but I am not confident in the reliability of that pipeline. This breaks the STAC item generation and loading process into two steps, using coiled to do the time-intensive item generation step.