### PR TITLE
set MAAP as host provider where it makes sense

### DIFF
--- a/set-host-provider.ipynb
+++ b/set-host-provider.ipynb
@@ -33,10 +33,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "id": "b9fc42f9",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/henry/.cache/uv/environments-v2/juv-tmp-t61w-nu1-847bdfd6ae1fc25c/lib/python3.13/site-packages/pystac/collection.py:703: DeprecatedWarning: The collection 'icesat2-boreal' is deprecated.\n",
+      "  warnings.warn(\n"
+     ]
+    }
+   ],
    "source": [
     "import json\n",
     "import time\n",
@@ -63,7 +72,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "id": "4e313233-854f-4e30-abd0-ae75e0aef503",
    "metadata": {},
    "outputs": [
@@ -158,7 +167,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 3,
    "id": "c85c3520-59cf-46f0-a069-c75ad6698094",
    "metadata": {},
    "outputs": [
@@ -215,10 +224,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 4,
    "id": "c513366a-bac7-4ac3-9a52-3c57ca6f1251",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/henry/.cache/uv/environments-v2/juv-tmp-t61w-nu1-847bdfd6ae1fc25c/lib/python3.13/site-packages/pystac/collection.py:703: DeprecatedWarning: The collection 'icesat2-boreal' is deprecated.\n",
+      "  warnings.warn(\n"
+     ]
+    }
+   ],
    "source": [
     "updated_collections = {}\n",
     "\n",
@@ -275,7 +293,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 5,
    "id": "0af3afdd-6c50-4d66-9eb5-7e82c28e5321",
    "metadata": {},
    "outputs": [
@@ -437,7 +455,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 6,
    "id": "ad9d6e30-348f-4d88-b8e4-8afc69371984",
    "metadata": {},
    "outputs": [
@@ -522,7 +540,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 7,
    "id": "9ee0c39f-7f5b-4a14-b063-87cae18a833e",
    "metadata": {},
    "outputs": [
@@ -676,7 +694,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 8,
    "id": "317968f6-8ccc-48af-80a7-954f2a1c8876",
    "metadata": {},
    "outputs": [],
@@ -702,7 +720,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 9,
    "id": "19f2d72d-9e57-4093-84cc-bfa6a7d566bf",
    "metadata": {},
    "outputs": [
@@ -715,55 +733,54 @@
       "\n",
       "--- Processing batch 1 (messages 0 to 9) ---\n",
       "  Successfully published 10 messages in this batch.\n",
-      "    - ID: msg-0000, SNS MessageId: 1d8e04df-5710-5138-99b2-643958fc954a\n",
-      "    - ID: msg-0001, SNS MessageId: 8a744239-4ce0-5368-9d3f-22df430ce71a\n",
-      "    - ID: msg-0002, SNS MessageId: 19dee251-f6df-56d5-b220-82b7f93342a7\n",
-      "    - ID: msg-0003, SNS MessageId: 126ac72c-45d2-5d3e-9102-a7ca4a3e794c\n",
-      "    - ID: msg-0004, SNS MessageId: 64a236f5-e78e-5b02-98b1-5613e8624f70\n",
-      "    - ID: msg-0005, SNS MessageId: 79a5ae13-cb53-5c69-bf32-cef5c4bf981b\n",
-      "    - ID: msg-0006, SNS MessageId: 7e20c037-20f5-51b9-95e8-a0d12f19f5cb\n",
-      "    - ID: msg-0007, SNS MessageId: 9b332c0c-1c04-50fa-a8fb-4cea13e85488\n",
-      "    - ID: msg-0008, SNS MessageId: c41a8774-8fc6-5544-873f-e792802a7136\n",
-      "    - ID: msg-0009, SNS MessageId: acd8766d-e1d3-565b-8115-168bee3f0229\n",
+      "    - ID: msg-0000, SNS MessageId: 3aaa25d6-29bf-5a8c-89da-45305d9b90fb\n",
+      "    - ID: msg-0001, SNS MessageId: 25aaf962-ff80-5f66-8276-99848ba4d511\n",
+      "    - ID: msg-0002, SNS MessageId: 2d9914b3-9bde-54e7-bedb-7455effa7e90\n",
+      "    - ID: msg-0003, SNS MessageId: 882fb251-0e41-5d1c-a145-d2b77a65b76b\n",
+      "    - ID: msg-0004, SNS MessageId: 8747c3d7-7d59-56cc-8ed6-a331097d1cbb\n",
+      "    - ID: msg-0005, SNS MessageId: 46762244-0479-59a6-8fce-42a2705dc3d1\n",
+      "    - ID: msg-0006, SNS MessageId: 1d630386-d862-56f8-ba08-6360ac46fc8f\n",
+      "    - ID: msg-0007, SNS MessageId: fd36a242-c75b-5e84-b42c-c2a4b37f64f3\n",
+      "    - ID: msg-0008, SNS MessageId: a1c630c0-2a1b-5b83-a86b-50265e3f21f4\n",
+      "    - ID: msg-0009, SNS MessageId: 4f57cce2-6de0-5be6-81e0-ac0419c45191\n",
       "\n",
       "--- Processing batch 2 (messages 10 to 19) ---\n",
       "  Successfully published 10 messages in this batch.\n",
-      "    - ID: msg-0010, SNS MessageId: 543869f2-bb7e-52d5-9b61-0914b49246a7\n",
-      "    - ID: msg-0011, SNS MessageId: 01a7b2e1-e7ae-5e90-bdaa-d207e8421ae2\n",
-      "    - ID: msg-0012, SNS MessageId: 66206328-8039-5c42-a6b2-03ce8fd56830\n",
-      "    - ID: msg-0013, SNS MessageId: 3243f834-e298-593f-9ae2-98d2ed74bd4d\n",
-      "    - ID: msg-0014, SNS MessageId: 5bb4597d-7854-580e-b56a-399b77b82c7c\n",
-      "    - ID: msg-0015, SNS MessageId: d948faab-b381-50c9-828a-9a4dbc6db4bb\n",
-      "    - ID: msg-0016, SNS MessageId: 54fecc93-5e2c-5e45-be75-ac7551c08a37\n",
-      "    - ID: msg-0017, SNS MessageId: 86ebc9e5-c24b-5670-a214-a903cda7f202\n",
-      "    - ID: msg-0018, SNS MessageId: 1548567f-c957-5170-ada7-3699c6bba502\n",
-      "    - ID: msg-0019, SNS MessageId: e8bc50e1-2f1a-5a5e-9c38-300720f6ee2c\n",
+      "    - ID: msg-0010, SNS MessageId: f7259b02-6390-5e9b-908c-fbe417b414ec\n",
+      "    - ID: msg-0011, SNS MessageId: 50b14b3f-f9a8-5b50-90ab-2bd98d8c5127\n",
+      "    - ID: msg-0012, SNS MessageId: e813e3bf-c172-5c2e-8f6d-8359b5560659\n",
+      "    - ID: msg-0013, SNS MessageId: d9feb133-9b9e-5dda-993d-d1d5efbac7ad\n",
+      "    - ID: msg-0014, SNS MessageId: f1ff34d4-3fb0-50ed-ad8a-54324b949a9a\n",
+      "    - ID: msg-0015, SNS MessageId: cbf85363-b72a-522f-90b4-3385c30e0858\n",
+      "    - ID: msg-0016, SNS MessageId: 50d6ccc4-6909-58f8-a3a0-ac221d2d528f\n",
+      "    - ID: msg-0017, SNS MessageId: 1aa24034-3fb5-5526-a287-20d24b91bf51\n",
+      "    - ID: msg-0018, SNS MessageId: 072efe84-2901-5a3d-b576-9e625d25304a\n",
+      "    - ID: msg-0019, SNS MessageId: 4b8af385-dfd7-5341-8bb1-9363abf37936\n",
       "\n",
       "--- Processing batch 3 (messages 20 to 29) ---\n",
       "  Successfully published 10 messages in this batch.\n",
-      "    - ID: msg-0020, SNS MessageId: 9be46861-ad68-5981-92e6-0887a2852df3\n",
-      "    - ID: msg-0021, SNS MessageId: 5adacf39-c509-5657-8d4e-afdfcae48225\n",
-      "    - ID: msg-0022, SNS MessageId: 8bb4580b-0cce-539e-8a6a-38ed0323b7ec\n",
-      "    - ID: msg-0023, SNS MessageId: d44f7ff9-8101-521b-9088-1f1f8eec7669\n",
-      "    - ID: msg-0024, SNS MessageId: d918d637-c561-56c7-97f5-b6d1ca8c82b5\n",
-      "    - ID: msg-0025, SNS MessageId: 8e98ec91-f584-5572-a4d8-8c77fa690100\n",
-      "    - ID: msg-0026, SNS MessageId: f13563f2-caef-578e-90f3-0314c50223fc\n",
-      "    - ID: msg-0027, SNS MessageId: 3c9b8509-439a-5a09-906f-e5ef4c77ee7b\n",
-      "    - ID: msg-0028, SNS MessageId: 4b328162-a78b-5f24-8568-e184a866eb56\n",
-      "    - ID: msg-0029, SNS MessageId: aaad7759-7310-5be3-a8a7-17bf7cfdff91\n",
+      "    - ID: msg-0020, SNS MessageId: acecbcd2-0abd-5188-822e-dc347e981bff\n",
+      "    - ID: msg-0021, SNS MessageId: 2d894ec8-e5b9-5b4f-b830-2e2e919c6138\n",
+      "    - ID: msg-0022, SNS MessageId: 866672c7-669c-51a2-9249-122112b9ebd5\n",
+      "    - ID: msg-0023, SNS MessageId: d10ad5af-c907-59d8-8380-b549bd2233af\n",
+      "    - ID: msg-0024, SNS MessageId: ccaaea83-168b-5271-8df8-8a6562aee806\n",
+      "    - ID: msg-0025, SNS MessageId: d257ddd6-7356-5cc0-a774-bd300773b6b7\n",
+      "    - ID: msg-0026, SNS MessageId: 2752baca-4c6d-58d9-bff9-da2c3848d2ae\n",
+      "    - ID: msg-0027, SNS MessageId: e06bce47-4df7-57ef-a536-aea139d2ed98\n",
+      "    - ID: msg-0028, SNS MessageId: fd7ec402-c081-52aa-835d-a4e4b4a498dd\n",
+      "    - ID: msg-0029, SNS MessageId: 7b18403d-e845-5bba-9481-20db9c6041cd\n",
       "\n",
       "--- Processing batch 4 (messages 30 to 31) ---\n",
       "  Successfully published 2 messages in this batch.\n",
-      "    - ID: msg-0030, SNS MessageId: 3d67260c-f964-5834-9fbc-46eaf6892c46\n",
-      "    - ID: msg-0031, SNS MessageId: cb9f2650-76e8-5e59-808d-46b679050a2b\n",
+      "    - ID: msg-0030, SNS MessageId: 49cfa0ef-ebba-50ee-b3d2-c0099f9f7a99\n",
+      "    - ID: msg-0031, SNS MessageId: e7cff3be-8260-5476-9191-9358f645ee01\n",
       "\n",
       "--- All batches processed ---\n"
      ]
     }
    ],
    "source": [
-    "stac_loader_topic_arn = \"arn:aws:sns:us-west-2:916098889494:MAAP-STAC-test-pgSTAC-stacitemloaderTopicD9D06088-LutBraKgk6sT\"\n",
-    "\n",
+    "stac_loader_topic_arn = \"arn:aws:sns:us-west-2:916098889494:MAAP-STAC-dev-pgSTAC-stacitemloaderTopicD9D06088-m0iaNFNtnXUP\"\n",
     "\n",
     "sns_client = boto3.client(\"sns\")\n",
     "\n",


### PR DESCRIPTION
This notebook will set the 'host' role to the appropriate `Provider`.

TODO:

- [x] set MAAP as host provider for all collections with assets in a MAAP bucket
- [x] set alternate host provider for all collections with assets in a non-MAAP bucket
- [x] post changes to our STAC database 

resolves https://github.com/NASA-IMPACT/active-maap-sprint/issues/1189